### PR TITLE
adjust source file targets to make library compatible with Android 7

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -36,7 +36,7 @@
                 $BACKGROUND_MODE_LOCATION
             </array>
         </config-file>
-        
+
         <config-file target="*-Info.plist" parent="NSLocationAlwaysAndWhenInUseUsageDescription">
             <string>$LOCATION_ALWAYS_AND_WHEN_IN_USE_USAGE_DESCRIPTION</string>
         </config-file>
@@ -99,13 +99,13 @@
         <preference name="APPCOMPAT_VERSION" default="27.0.0" />
         <framework src="com.android.support:appcompat-v7:$APPCOMPAT_VERSION"/>
         <framework src="src/android/build.gradle" custom="true" type="gradleReference" />
-        <resource-file src="src/android/libs/tslocationmanager.aar" target="src/android/libs/tslocationmanager.aar" />
+        <resource-file src="src/android/libs/tslocationmanager.aar" target="libs/tslocationmanager.aar" />
 
-        <source-file src="src/android/CDVBackgroundGeolocation.java" target-dir="src/com/transistorsoft/cordova/bggeo" />
-        <source-file src="src/android/HeadlessBroadcastReceiver.java" target-dir="src/com/transistorsoft/cordova/bggeo" />
-        <source-file src="src/android/HeadlessJobService.java" target-dir="src/com/transistorsoft/cordova/bggeo" />
+        <source-file src="src/android/CDVBackgroundGeolocation.java" target-dir="app/src/main/com/transistorsoft/cordova/bggeo" />
+        <source-file src="src/android/HeadlessBroadcastReceiver.java" target-dir="app/src/main/com/transistorsoft/cordova/bggeo" />
+        <source-file src="src/android/HeadlessJobService.java" target-dir="app/src/main/com/transistorsoft/cordova/bggeo" />
          />
-        <source-file src="src/android/HeadlessTask.java" target-dir="src/com/transistorsoft/cordova/bggeo" />
+        <source-file src="src/android/HeadlessTask.java" target-dir="app/src/main/com/transistorsoft/cordova/bggeo" />
 
         <config-file target="res/xml/config.xml" parent="/*">
             <feature name="BackgroundGeolocation">

--- a/src/android/build.gradle
+++ b/src/android/build.gradle
@@ -1,7 +1,7 @@
-repositories{    
+repositories{
   jcenter()
   flatDir{
-    dirs 'src/android/libs'
+    dirs 'src/main/libs'
   }
   // Google dependencies are now hosted at Maven
   maven {


### PR DESCRIPTION
Modifies the target-dir for several source files to fit with the Android 7's directory structure. Addresses the errors that were seen in this issue: https://github.com/transistorsoft/cordova-background-geolocation-lt/issues/614.

As @christocracy mentioned in the issue, this will likely create issues for those building older versions of Android. If there's a way to do this in a more compatible way, I'd be happy to adjust the PR. This was what it took to get it working for me though, so I thought I'd try to share it.