### PR TITLE
Update the build.gradle

### DIFF
--- a/src/android/build.gradle
+++ b/src/android/build.gradle
@@ -40,11 +40,11 @@ dependencies {
 * Background Geolocation's aar includes about 1.5M of mp3 sound-files for its debugging sound FX.
 * This method strips those mp3s out in RELEASE builds.
 */
-ext.postBuildExtras = {
+cdvPluginPostBuildExtras.add({
   android {
     purgeBackgroundGeolocationDebugResources(applicationVariants)
   }
-}
+})
 
 def purgeBackgroundGeolocationDebugResources(applicationVariants) {
     if ((ext.has("removeBackgroundGeolocationDebugSoundsInRelease")) && (ext.removeBackgroundGeolocationDebugSoundsInRelease == false)) return


### PR DESCRIPTION
Cordova Jira Ticket Exapling the Bug this fixes
https://issues.apache.org/jira/browse/CB-14163

We had trouble using this plugin on android with other plugins that also try to use ext.postBuildExtras. 
We had cordova-support-google-services and cordova-plugin-code-push installed as well as this plugin and all three were trying to use postBuildExtras.
But only the last plugin listed in our config file would have its code executed at built time. the link above describes the cause of the issue pretty well