### PR TITLE
UserDir for capacitor project

### DIFF
--- a/src/android/build.gradle
+++ b/src/android/build.gradle
@@ -5,6 +5,7 @@ def libDir = "${projectDir}/libs"
 
 File capacitorConfig = new File("${userDir}/../capacitor.config.json")
 println("${TAG}: userDir:" ${userDir})
+println("${TAG}: projectDir:" ${projectDir})
 if (capacitorConfig.exists()) {
   def pluginName = ""
   def CORDOVA_BACKGROUND_GEOLOCATION_LT = "cordova-background-geolocation-lt"

--- a/src/android/build.gradle
+++ b/src/android/build.gradle
@@ -4,7 +4,7 @@ def userDir = System.getProperty("user.dir")
 def libDir = "${projectDir}/libs"
 
 File capacitorConfig = new File("${userDir}/../capacitor.config.json")
-
+println("${TAG}: userDir:" ${userDir})
 if (capacitorConfig.exists()) {
   def pluginName = ""
   def CORDOVA_BACKGROUND_GEOLOCATION_LT = "cordova-background-geolocation-lt"

--- a/src/android/build.gradle
+++ b/src/android/build.gradle
@@ -1,7 +1,7 @@
 def TAG = "[cordova-background-geolocation] "
 
 def userDir = System.getProperty("user.dir")
-def libDir = "${projectDir}/libs"
+// def libDir = "${projectDir}/libs"
 
 File capacitorConfig = new File("${userDir}/capacitor.config.json")
 println("${TAG}: userDir: ${userDir}")

--- a/src/android/build.gradle
+++ b/src/android/build.gradle
@@ -4,8 +4,8 @@ def userDir = System.getProperty("user.dir")
 def libDir = "${projectDir}/libs"
 
 File capacitorConfig = new File("${userDir}/../capacitor.config.json")
-println("${TAG}: userDir:" ${userDir})
-println("${TAG}: projectDir:" ${projectDir})
+println("${TAG}: userDir: ${userDir}")
+println("${TAG}: projectDir: ${projectDir}")
 if (capacitorConfig.exists()) {
   def pluginName = ""
   def CORDOVA_BACKGROUND_GEOLOCATION_LT = "cordova-background-geolocation-lt"

--- a/src/android/build.gradle
+++ b/src/android/build.gradle
@@ -3,7 +3,7 @@ def TAG = "[cordova-background-geolocation] "
 def userDir = System.getProperty("user.dir")
 def libDir = "${projectDir}/libs"
 
-File capacitorConfig = new File("${userDir}/../capacitor.config.json")
+File capacitorConfig = new File("${userDir}/capacitor.config.json")
 println("${TAG}: userDir: ${userDir}")
 println("${TAG}: projectDir: ${projectDir}")
 if (capacitorConfig.exists()) {
@@ -12,7 +12,7 @@ if (capacitorConfig.exists()) {
   def CORDOVA_BACKGROUND_GEOLOCATION    = "cordova-background-geolocation"
 
   // Capacitor app
-  libDir = "${userDir}/../node_modules"
+  libDir = "${userDir}/node_modules"
 
   File folder = new File("${libDir}/${CORDOVA_BACKGROUND_GEOLOCATION}")
 

--- a/src/android/build.gradle
+++ b/src/android/build.gradle
@@ -1,7 +1,7 @@
 def TAG = "[cordova-background-geolocation] "
 
 def userDir = System.getProperty("user.dir")
-// def libDir = "${projectDir}/libs"
+def libDir = "${projectDir}/libs"
 
 File capacitorConfig = new File("${userDir}/capacitor.config.json")
 println("${TAG}: userDir: ${userDir}")


### PR DESCRIPTION
This is one option that works for me.  Another alternative may be to make the userDir relative to the projectDir.

It seems that user.dir is not reliable since it is typically this is the directory where java started and may not be the same for every case.